### PR TITLE
Add Null entity so we can hide transforms using input_type

### DIFF
--- a/src/canari/maltego/entities.py
+++ b/src/canari/maltego/entities.py
@@ -41,6 +41,7 @@ __all__ = [
     'Netblock',
     'NominatimLocation',
     'NSRecord',
+    'Null',
     'Person',
     'PhoneNumber',
     'Phrase',
@@ -57,6 +58,10 @@ __all__ = [
 
 class Unknown(Entity):
     _category_ = 'Unknown'
+
+
+class Null(Entity):
+    pass
 
 
 class GPS(Entity):


### PR DESCRIPTION
This provides the ability to create the following:

```python
# Hidden
class doSomething(Transform):
    # The transform input entity type.
    input_type = Null

    def do_transform(self, request, response, config):
        result = some_api_call(request.entity.value)
        response += Phrase('%s' % result)
        return response

# Visible
class doSomethingToEmailAddress(doSomething):
    input_type=EmailAddress

# Visible
class doSomethingToURL(doSomething):
    input_type=URL
```

Then in Maltego the user will only see the two transforms that are commented as Visible and only against the appropriate entities.

I couldn't find an obvious alternative that would allow me to do this without doSomething being displayed on all entities.
