### PR TITLE
Bug Fix - Unable to install Plume when not using virtualenv

### DIFF
--- a/src/canari/commands/install_plume.py
+++ b/src/canari/commands/install_plume.py
@@ -166,6 +166,8 @@ def install_wizard(opts):
             "--> Canari has detected that you're running this install script from within a virtualenv.\n"
             "--> Would you like to run Plume from this virtualenv (%r) as well?" % os.environ['VIRTUAL_ENV'], True)
         configurator.variables['plume.venv'] = os.environ['VIRTUAL_ENV'] if run_venv else False
+    else:
+        configurator.variables['plume.venv'] = None
 
     configurator.render()
     finish(configurator)


### PR DESCRIPTION
When attempting to install plume using the "install_plume" command, the script would exit with an exception containing the following text:  jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'venv'.  

By adding the two lines below, the dictionary will receive a key with the name 'plume.venv' which will allow the script to install correctly.