### PR TITLE
fix: Unknown Entity namespace - fixes #51

### DIFF
--- a/src/canari/maltego/message.py
+++ b/src/canari/maltego/message.py
@@ -761,6 +761,7 @@ class Entity(with_metaclass(EntityTypeFactory, object)):
 
 class Unknown(Entity):
     _category_ = 'Unknown'
+    _namespace_ = 'maltego'
 
 
 class MaltegoTransformRequestMessage(MaltegoElement):


### PR DESCRIPTION
This fixes a missing namespace preventing us to use the Unknown Entity, which is the base inherited Entity  to all.