### PR TITLE
Support Maltego's entity inheritance model

### DIFF
--- a/src/canari/maltego/configuration.py
+++ b/src/canari/maltego/configuration.py
@@ -394,6 +394,14 @@ class EntityProperties(MaltegoElement):
     fields = fields_.Dict(Field, key='name', tagname='Fields', required=False)
 
 
+class BaseEntities(MaltegoElement):
+
+    class meta:
+        tagname = 'BaseEntities'
+
+    base_entity = fields_.String(tagname='BaseEntity', default='')
+
+
 class RegexGroup(MaltegoElement):
 
     property = fields_.String(required=False)
@@ -421,3 +429,4 @@ class MaltegoEntity(MaltegoElement):
     smallicontag = fields_.String(tagname='SmallIcon', required=False)
     converter = fields_.Model(Converter, required=False)
     properties = fields_.Model(EntityProperties, required=False)
+    base = fields_.Model(BaseEntities, required=False)


### PR DESCRIPTION
read the inheritance properties from xml files.

This is a first step in fixing #57 

TODO:
- Should canari use that information to build a python class inheritance model based on Maltego's, or not. (probably yes)