### PR TITLE
fix bad request in remote_transform command

### DIFF
--- a/src/canari/maltego/runner.py
+++ b/src/canari/maltego/runner.py
@@ -77,7 +77,7 @@ def remote_canari_transform_runner(host, base_path, transform, entities, paramet
     if is_debug_exec_mode():
         sys.stderr.write("Sending following message to {}{}:\n{}\n\n".format(host, path, msg))
 
-    c.request('POST', path, message, headers={'Content-Type': 'application/xml'})
+    c.request('POST', path, msg, headers={'Content-Type': 'application/xml'})
 
     return c.getresponse()
 


### PR DESCRIPTION
There is no reference to variable message in function _remote_canari_transform_runner_, it should be _msg_. This fix enables the _remote_transform_ command to work properly. I think this command is missing proper doc so next time I'll try to add it.