### PR TITLE
fix: [entities] fixes issue #65  Hashtag has incorrect default name

### DIFF
--- a/src/canari/maltego/entities.py
+++ b/src/canari/maltego/entities.py
@@ -342,7 +342,7 @@ class Hash(Entity):
 
 class Hashtag(Entity):
     _category_ = 'Social'
-    hashtag = StringEntityField('twitter.hashtag', display_name='Hashtag', is_value=True)
+    hashtag = StringEntityField('maltego.hashtag', display_name='Hashtag', is_value=True)
 
 
 class Company(Entity):


### PR DESCRIPTION
This fixes issue #65 where the unique name for Hashtag is not the default one from Maltego.
